### PR TITLE
Added internet permission to the manifest.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="sistemas.puc.com.finantialapp">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
Closes #29 

As described in the android documentation, normal permissions don't need to be requested at runtime, not even in SDK 23 or higher, since these permissions are granted automatically.

https://developer.android.com/training/permissions/requesting.html#perm-check