### PR TITLE
Add base moeda

### DIFF
--- a/app/src/main/java/sistemas/puc/com/finantialapp/FetchRatesTask.java
+++ b/app/src/main/java/sistemas/puc/com/finantialapp/FetchRatesTask.java
@@ -145,12 +145,12 @@ public class FetchRatesTask extends AsyncTask<String, Void, List<ContentValues>>
             result.add(moedaValues);
         }
 
-        ContentValues brlValue = new ContentValues();
-        brlValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_CODE, MoedaFragment.MOEDA_BASE);
-        brlValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_NAME, MoedaMap.getCurrencyName(MoedaFragment.MOEDA_BASE));
-        brlValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_RATE, 1);
-        brlValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_DATE, time);
-        result.add(brlValue);
+        ContentValues baseMoedaValue = new ContentValues();
+        baseMoedaValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_CODE, MoedaFragment.MOEDA_BASE);
+        baseMoedaValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_NAME, MoedaMap.getCurrencyName(MoedaFragment.MOEDA_BASE));
+        baseMoedaValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_RATE, 1);
+        baseMoedaValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_DATE, time);
+        result.add(baseMoedaValue);
 
         return result;
     }

--- a/app/src/main/java/sistemas/puc/com/finantialapp/FetchRatesTask.java
+++ b/app/src/main/java/sistemas/puc/com/finantialapp/FetchRatesTask.java
@@ -146,8 +146,9 @@ public class FetchRatesTask extends AsyncTask<String, Void, List<ContentValues>>
         }
 
         ContentValues baseMoedaValue = new ContentValues();
+        String baseMoedaName = MoedaMap.getCurrencyName(MoedaFragment.MOEDA_BASE);
         baseMoedaValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_CODE, MoedaFragment.MOEDA_BASE);
-        baseMoedaValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_NAME, MoedaMap.getCurrencyName(MoedaFragment.MOEDA_BASE));
+        baseMoedaValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_NAME, baseMoedaName);
         baseMoedaValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_RATE, 1);
         baseMoedaValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_DATE, time);
         result.add(baseMoedaValue);

--- a/app/src/main/java/sistemas/puc/com/finantialapp/FetchRatesTask.java
+++ b/app/src/main/java/sistemas/puc/com/finantialapp/FetchRatesTask.java
@@ -145,6 +145,13 @@ public class FetchRatesTask extends AsyncTask<String, Void, List<ContentValues>>
             result.add(moedaValues);
         }
 
+        ContentValues brlValue = new ContentValues();
+        brlValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_CODE, MoedaFragment.MOEDA_BASE);
+        brlValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_NAME, MoedaMap.getCurrencyName(MoedaFragment.MOEDA_BASE));
+        brlValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_RATE, 1);
+        brlValue.put(FinantialContract.MoedaEntry.COLUMN_MOEDA_DATE, time);
+        result.add(brlValue);
+
         return result;
     }
 }

--- a/app/src/main/java/sistemas/puc/com/finantialapp/MoedaFragment.java
+++ b/app/src/main/java/sistemas/puc/com/finantialapp/MoedaFragment.java
@@ -24,7 +24,7 @@ public class MoedaFragment extends Fragment implements
         LoaderManager.LoaderCallbacks<Cursor>,
         RecyclerItemClickAdapter.OnItemClickListener {
 
-    private static final String REAL = "USD";
+    public static final String MOEDA_BASE = "BRL";
 
     private static final Uri MOEDA_URI = MoedaEntry.CONTENT_URI;
 
@@ -101,7 +101,7 @@ public class MoedaFragment extends Fragment implements
     public void onItemClick(View view, int position) {
         if (m_cursor != null) {
             Intent intent = new Intent(getContext(), ConversaoActivity.class);
-            intent.putExtra(ConversaoActivity.EXTRA_LEFT_MOEDA, REAL);
+            intent.putExtra(ConversaoActivity.EXTRA_LEFT_MOEDA, MOEDA_BASE);
 
             m_cursor.moveToPosition(position);
             int codeColumnIndex = m_cursor.getColumnIndexOrThrow(MoedaEntry.COLUMN_MOEDA_CODE);

--- a/app/src/main/java/sistemas/puc/com/finantialapp/model/Database.java
+++ b/app/src/main/java/sistemas/puc/com/finantialapp/model/Database.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import sistemas.puc.com.finantialapp.FetchRatesTask;
+import sistemas.puc.com.finantialapp.MoedaFragment;
 import sistemas.puc.com.finantialapp.entities.IndiceItem;
 import sistemas.puc.com.finantialapp.entities.MoedaItem;
 import sistemas.puc.com.finantialapp.entities.TesouroItem;
@@ -69,7 +70,7 @@ public final class Database {
 
     public static void update(Context c) {
         FetchRatesTask frt = new FetchRatesTask(c);
-        frt.execute("BRL"); // TODO: where should this string come from?
+        frt.execute(MoedaFragment.MOEDA_BASE);
         Toast.makeText(c, "Database updated.", Toast.LENGTH_SHORT).show();
     }
 }


### PR DESCRIPTION
This adds a base currency to the list when fetching exchange rates.
The base currency is still shown in the list, which should not happen. (This will be added as an issue and solved by another PR)
Closes #93 